### PR TITLE
add config options for melter/heater fuels temperature

### DIFF
--- a/src/main/java/knightminer/tcomplement/TinkersComplement.java
+++ b/src/main/java/knightminer/tcomplement/TinkersComplement.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import knightminer.tcomplement.common.Config;
 import knightminer.tcomplement.common.TCompNetwork;
 import knightminer.tcomplement.feature.ModuleFeature;
+import knightminer.tcomplement.feature.tileentity.TileMelter;
 import knightminer.tcomplement.plugin.ceramics.CeramicsPlugin;
 import knightminer.tcomplement.plugin.chisel.ChiselPlugin;
 import knightminer.tcomplement.plugin.exnihilo.ExNihiloPlugin;
@@ -15,6 +16,7 @@ import net.minecraft.util.datafix.FixTypes;
 import net.minecraftforge.common.util.ModFixs;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import slimeknights.mantle.common.GuiHandler;
@@ -61,4 +63,9 @@ public class TinkersComplement {
 		ModFixs fixer = FMLCommonHandler.instance().getDataFixer().init(modID, 1);
 		fixer.registerFix(FixTypes.BLOCK_ENTITY, new TileEntityRenamer());
 	}
+
+	@Mod.EventHandler
+	public void init(FMLInitializationEvent event) {
+		TileMelter.init();
+  }
 }

--- a/src/main/java/knightminer/tcomplement/common/Config.java
+++ b/src/main/java/knightminer/tcomplement/common/Config.java
@@ -18,7 +18,8 @@ public class Config {
 
 	public static float oreToIngotRatio = 1.0f;
 	public static boolean blacklistMelterStone = true;
-
+	public static String[] heaterFuels;
+	public static int defaultHeaterFuelTemperature;
 
 	static Configuration configFile;
 
@@ -30,6 +31,8 @@ public class Config {
 				"Disallows creating seared stone in the melter using cobblestone or tool parts");
 		oreToIngotRatio = configFile.getFloat("oreToIngotRatio", "melter", 1.0f, 0f, 16.0f,
 				"Ratio of ore to material produced in the melter.");
+		heaterFuels = configFile.getStringList("heaterFuels", "melter", new String[]{}, "List of fuels that can be used in the heater and their respective temp (in Celcius).items mod:xxx[:data_value]=temp\nFuels in this list require to be valid minecraft furnace fuels.");
+		defaultHeaterFuelTemperature = configFile.getInt("defaultHeaterFuelTemperature", "melter", 200,0, Integer.MAX_VALUE, "Default temperature (in Celcius) for any valid fuel that is not registred in heaterFuels.\nIf set to 0, disable all heater fuels but the ones in heaterFuels.\n200 is meant to be just about enough to melt clay or most metals, but not iron");
 
 		if(configFile.hasChanged()) {
 			configFile.save();

--- a/src/main/java/knightminer/tcomplement/feature/inventory/SlotHeaterFuel.java
+++ b/src/main/java/knightminer/tcomplement/feature/inventory/SlotHeaterFuel.java
@@ -1,18 +1,18 @@
 package knightminer.tcomplement.feature.inventory;
 
+import knightminer.tcomplement.feature.tileentity.TileMelter;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
 
 public class SlotHeaterFuel extends SlotItemHandler {
-
 	public SlotHeaterFuel(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
 		super(itemHandler, index, xPosition, yPosition);
 	}
 
 	@Override
 	public boolean isItemValid(ItemStack stack) {
-		return TileEntityFurnace.isItemFuel(stack);
+		return TileMelter.isFuelValid(stack);
 	}
 }


### PR DESCRIPTION

A simple addition to the configuration file to allow configuration of fuels for the heater.

- defaultHeaterFuelTemperature, set by default to the current fuel temperature (200). It drives the temperature for any fuel that is used in the heater
- heaterFuels, provides a possible list of fuels with their respective temperatures (mod:item[:data_value]=temp). Default is empty.

With the default config, the mod should behave exactly as before (all fuels burn at 200). However, these options allow to set different temperatures to specific fuels or to disable some others (setting temperature at 0). You can also disable all fuels but the specified one by setting the defaultHeaterFuelTemperature to 0.




