### PR TITLE
Exposed private method of TCompRegistry

### DIFF
--- a/src/main/java/knightminer/tcomplement/library/TCompRegistry.java
+++ b/src/main/java/knightminer/tcomplement/library/TCompRegistry.java
@@ -313,7 +313,7 @@ public class TCompRegistry {
 	\*-------------------------------------------------------------------------*/
 	private static List<HighOvenFuel> highOvenFuels = Lists.newLinkedList();
 
-	private static void registerFuel(HighOvenFuel fuel) {
+	public static void registerFuel(HighOvenFuel fuel) {
 		if(new TCompRegisterEvent.HighOvenFuelRegisterEvent(fuel).fire()) {
 			highOvenFuels.add(fuel);
 		}


### PR DESCRIPTION
Hi KnightMiner,

I'm working on addind CraftTweaker compatibility for the high oven, through ModTweaker. Being able to subclass `HighOvenFuel` and then register custom instances would allow better filtering for the registration event. This, in turn, make removing default fuels easier to code, and to use within zenscript. (see [here](https://github.com/Riernar/ModTweaker/blob/1.12/src/main/java/com/blamejared/compat/tcomplement/highoven/HighOven.java) for details)

Exposing the method extends the design of heat and mix recipes - though there is no interface. If you would rather have an interface than subclasses, I can try to make one.

