### PR TITLE
Fix https://github.com/KnightMiner/TinkersComplement/issues/56

### DIFF
--- a/src/main/java/knightminer/tcomplement/plugin/chisel/items/ItemChisel.java
+++ b/src/main/java/knightminer/tcomplement/plugin/chisel/items/ItemChisel.java
@@ -123,6 +123,13 @@ public class ItemChisel extends AoeToolCore implements IChiselItem {
 	@Optional.Method(modid="chisel")
 	@Override
 	public boolean onChisel(World world, EntityPlayer player, ItemStack chisel, ICarvingVariation target) {
+		if (ToolHelper.getCurrentDurability(chisel) <= 0) {
+			NBTTagCompound tags = TagUtil.getTagSafe(chisel);
+			if (tags.getCompoundTag("chiseldata").hasKey("target")) {
+				tags.getCompoundTag("chiseldata").removeTag("target");
+				chisel.setTagCompound(tags);
+			}
+		}
 		return true;
 	}
 


### PR DESCRIPTION
Fixes the issue by simply wiping the nbt tag compound for the chisel's target if the durability <= 0.
The items will still drop from the players inventory so nothing is lost.